### PR TITLE
簡単にojichatを使う

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ go get -u github.com/greymd/ojichat
 GO111MODULE=off go get -u github.com/greymd/ojichat
 ```
 
+#### Gitpodを使って簡単に利用する
+
+リンクを開くとojichatが利用できます。
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/greymd/ojichat)
+
 ## 使い方
 
 ```bash


### PR DESCRIPTION
ojichatを使うためにはGo又はDockerの構築が必要です。
この手間を省くためにWeb上で使える私達の[Gitpod](https://www.gitpod.io/)と言うオンラインIDEを利用すると良いのではと感じました。

READMEに追加したURLを踏んでいただく事で起動後にすぐojichatを利用することができます。

良ければマージしてojichatのユーザーを増やしてください！